### PR TITLE
chore: add-to-project reusable workflow (#1)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,24 @@
+name: Add to project
+
+on:
+  workflow_call:
+    inputs:
+      project-url:
+        description: "GitHub Projects V2 URL (e.g. https://github.com/orgs/rararulab/projects/1)"
+        type: string
+        required: true
+    secrets:
+      ADD_TO_PROJECT_TOKEN:
+        description: "PAT with project write scope"
+        required: true
+
+jobs:
+  add-to-project:
+    name: Add to project board
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ inputs.project-url }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}

--- a/docs/add-to-project.md
+++ b/docs/add-to-project.md
@@ -1,0 +1,25 @@
+# add-to-project
+
+Automatically add new issues and PRs to a GitHub Projects V2 board.
+
+## Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project-url` | string | *required* | GitHub Projects V2 URL |
+
+## Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `ADD_TO_PROJECT_TOKEN` | PAT with `project` write scope |
+
+## Caller Trigger
+
+```yaml
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+```

--- a/templates/add-to-project.yml
+++ b/templates/add-to-project.yml
@@ -1,0 +1,17 @@
+# Auto-add issues and PRs to org project board
+# Copy to: .github/workflows/add-to-project.yml
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    uses: rararulab/workflows/.github/workflows/add-to-project.yml@main
+    with:
+      project-url: https://github.com/orgs/rararulab/projects/1
+    secrets:
+      ADD_TO_PROJECT_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

- Add reusable workflow (`add-to-project.yml`) using `actions/add-to-project@v1.0.2` to auto-add issues/PRs to a GitHub Projects V2 board
- Add documentation (`docs/add-to-project.md`) describing inputs, secrets, and caller trigger
- Add caller template (`templates/add-to-project.yml`) pre-filled with org project URL

## Type of change

| Type | Label |
|------|-------|
| Maintenance | `chore` |

## Component

`ci`

## Closes

Closes #1

## Test plan

- [x] Workflow YAML is valid
- [x] Follows existing repo patterns (workflow_call trigger, docs, template)
- [x] Action pinned to `v1.0.2`
- [x] Secret passed via `secrets`, not hardcoded