### PR TITLE
chore: fix review findings — action versions, defaults (#5)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,6 +6,8 @@ on:
       runner:
         description: "Runner label"
         type: string
+        # arc-runner-set: private repos on GitHub Free plan cannot use
+        # ubuntu-latest for reusable workflows triggered by non-public callers.
         default: "arc-runner-set"
       project-url:
         description: "GitHub Projects V2 URL (e.g. https://github.com/orgs/rararulab/projects/1)"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -17,7 +17,7 @@ on:
       runner:
         description: "Runner label"
         type: string
-        default: "self-hosted"
+        default: "ubuntu-latest"
 
 concurrency:
   group: pages-${{ github.ref }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -6,7 +6,7 @@ on:
       go-version:
         description: "Go version to use"
         type: string
-        default: "1.26"
+        default: "stable"
       runner:
         description: "Runner label"
         type: string
@@ -37,7 +37,7 @@ jobs:
     name: Lint
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -67,7 +67,7 @@ jobs:
       matrix:
         os: ${{ fromJson(inputs.test-matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -93,7 +93,7 @@ jobs:
       matrix:
         os: ${{ fromJson(inputs.test-matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -110,7 +110,7 @@ jobs:
         run: ./bin/${{ inputs.build-binary }} --help
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.build-binary }}-${{ matrix.os }}
           path: bin/${{ inputs.build-binary }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -31,7 +31,7 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'chore(release):')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/docs/deploy-pages.md
+++ b/docs/deploy-pages.md
@@ -8,6 +8,6 @@ Build a static site and deploy to GitHub Pages (gh-pages branch).
 |-------|------|---------|-------------|
 | `build-command` | string | *required* | Build command (e.g. `mdbook build docs`) |
 | `output-dir` | string | *required* | Directory with built files |
-| `runner` | string | `self-hosted` | Runner label |
+| `runner` | string | `ubuntu-latest` | Runner label |
 
 Only deploys on `push` and `workflow_dispatch` events (skips on PRs).

--- a/docs/go-ci.md
+++ b/docs/go-ci.md
@@ -6,7 +6,7 @@ Go lint + test + optional binary build.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `go-version` | string | `1.26` | Go version |
+| `go-version` | string | `stable` | Go version |
 | `runner` | string | `ubuntu-latest` | Runner for lint job |
 | `build-binary` | string | `""` | Binary name (empty = skip build) |
 | `build-path` | string | `.` | Go build path |


### PR DESCRIPTION
## Summary

- **go-ci.yml**: Fix `go-version` default from `1.26` (non-existent) to `stable`
- **go-ci.yml, go-release.yml**: Upgrade `actions/checkout` from v4 to v6, `actions/upload-artifact` from v4 to v6
- **deploy-pages.yml**: Change runner default from `self-hosted` to `ubuntu-latest`
- **add-to-project.yml**: Add comment explaining why `arc-runner-set` is the default (private repos on Free plan)
- **docs**: Update `go-ci.md` and `deploy-pages.md` to reflect new defaults

## Type of change

| Type | Label |
|------|-------|
| Chore | `chore` |

## Component

`ci`

## Closes

Closes #5

## Test plan

- [x] Verified all YAML files are syntactically valid
- [x] docs match workflow defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)